### PR TITLE
🍕🐛🔥📝🎨 Add catalogue schema , Fix slug + fetch data bug

### DIFF
--- a/sanity/package-lock.json
+++ b/sanity/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^16.4.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.2.1",
         "sanity": "^3.44.0",
         "styled-components": "^6.1.8"
       },
@@ -9986,6 +9987,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.2.1.tgz",
+      "integrity": "sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/sanity/package.json
+++ b/sanity/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^16.4.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.2.1",
     "sanity": "^3.44.0",
     "styled-components": "^6.1.8"
   },

--- a/sanity/sanity.config.js
+++ b/sanity/sanity.config.js
@@ -2,6 +2,7 @@ import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
 import {schemaTypes} from './schemaTypes'
+import {deskStructure} from './schemaTypes/deskStructure'
 
 export default defineConfig({
   name: 'default',
@@ -10,7 +11,7 @@ export default defineConfig({
   projectId: process.env.SANITY_STUDIO_PROJECT_ID,
   dataset: process.env.SANITY_STUDIO_DATASET,
 
-  plugins: [structureTool(), visionTool()],
+  plugins: [structureTool({structure:deskStructure}), visionTool()],
 
   schema: {
     types: schemaTypes,

--- a/sanity/sanity.types.ts
+++ b/sanity/sanity.types.ts
@@ -68,6 +68,49 @@ export type Geopoint = {
   alt?: number
 }
 
+export type Catalogue = {
+  _id: string
+  _type: 'catalogue'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  title?: string
+  main_image?: {
+    asset?: {
+      _ref: string
+      _type: 'reference'
+      _weak?: boolean
+      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
+    }
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    _type: 'image'
+  }
+  recommend_land_direction?: string
+  area?: number
+  land_area_require?: string
+  bedroom?: number
+  bathroom?: number
+  nulti_purpose_area?: number
+  price?: number
+  model_sets?: Array<{
+    title?: string
+    image_sets?: Array<{
+      asset?: {
+        _ref: string
+        _type: 'reference'
+        _weak?: boolean
+        [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
+      }
+      hotspot?: SanityImageHotspot
+      crop?: SanityImageCrop
+      _type: 'image'
+      _key: string
+    }>
+    _key: string
+  }>
+}
+
 export type Blog = {
   _id: string
   _type: 'blog'
@@ -76,6 +119,7 @@ export type Blog = {
   _rev: string
   title?: string
   slug?: Slug
+  short_description?: string
   author?: string
   release_date?: string
   main_image?: {
@@ -89,7 +133,7 @@ export type Blog = {
     crop?: SanityImageCrop
     _type: 'image'
   }
-  blog_description?: Array<
+  content?: Array<
     | {
         children?: Array<{
           marks?: Array<string>

--- a/sanity/sanity.types.ts
+++ b/sanity/sanity.types.ts
@@ -89,9 +89,11 @@ export type Catalogue = {
   recommend_land_direction?: string
   area?: number
   land_area_require?: string
-  bedroom?: number
-  bathroom?: number
-  nulti_purpose_area?: number
+  rooms?: Array<{
+    room_title?: string
+    quantity?: number
+    _key: string
+  }>
   price?: number
   model_sets?: Array<{
     title?: string
@@ -120,7 +122,12 @@ export type Blog = {
   title?: string
   slug?: Slug
   short_description?: string
-  author?: string
+  author?: {
+    _ref: string
+    _type: 'reference'
+    _weak?: boolean
+    [internalGroqTypeReferenceTo]?: 'author'
+  }
   release_date?: string
   main_image?: {
     asset?: {
@@ -166,6 +173,26 @@ export type Blog = {
         _key: string
       }
   >
+}
+
+export type Author = {
+  _id: string
+  _type: 'author'
+  _createdAt: string
+  _updatedAt: string
+  _rev: string
+  name?: string
+  profile?: {
+    asset?: {
+      _ref: string
+      _type: 'reference'
+      _weak?: boolean
+      [internalGroqTypeReferenceTo]?: 'sanity.imageAsset'
+    }
+    hotspot?: SanityImageHotspot
+    crop?: SanityImageCrop
+    _type: 'image'
+  }
 }
 
 export type Portfolio = {

--- a/sanity/schema.json
+++ b/sanity/schema.json
@@ -326,6 +326,267 @@
     }
   },
   {
+    "name": "catalogue",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "catalogue"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "title": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "main_image": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "asset": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "sanity.imageAsset"
+              },
+              "optional": true
+            },
+            "hotspot": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageHotspot"
+              },
+              "optional": true
+            },
+            "crop": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageCrop"
+              },
+              "optional": true
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "image"
+              }
+            }
+          }
+        },
+        "optional": true
+      },
+      "recommend_land_direction": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "area": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "number"
+        },
+        "optional": true
+      },
+      "land_area_require": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "bedroom": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "number"
+        },
+        "optional": true
+      },
+      "bathroom": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "number"
+        },
+        "optional": true
+      },
+      "nulti_purpose_area": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "number"
+        },
+        "optional": true
+      },
+      "price": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "number"
+        },
+        "optional": true
+      },
+      "model_sets": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "title": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "image_sets": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "array",
+                  "of": {
+                    "type": "object",
+                    "attributes": {
+                      "asset": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "object",
+                          "attributes": {
+                            "_ref": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "_type": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string",
+                                "value": "reference"
+                              }
+                            },
+                            "_weak": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "boolean"
+                              },
+                              "optional": true
+                            }
+                          },
+                          "dereferencesTo": "sanity.imageAsset"
+                        },
+                        "optional": true
+                      },
+                      "hotspot": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "inline",
+                          "name": "sanity.imageHotspot"
+                        },
+                        "optional": true
+                      },
+                      "crop": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "inline",
+                          "name": "sanity.imageCrop"
+                        },
+                        "optional": true
+                      },
+                      "_type": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string",
+                          "value": "image"
+                        }
+                      }
+                    },
+                    "rest": {
+                      "type": "object",
+                      "attributes": {
+                        "_key": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "optional": true
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
     "name": "blog",
     "type": "document",
     "attributes": {
@@ -372,6 +633,13 @@
         "value": {
           "type": "inline",
           "name": "slug"
+        },
+        "optional": true
+      },
+      "short_description": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
         },
         "optional": true
       },
@@ -451,7 +719,7 @@
         },
         "optional": true
       },
-      "blog_description": {
+      "content": {
         "type": "objectAttribute",
         "value": {
           "type": "array",

--- a/sanity/schema.json
+++ b/sanity/schema.json
@@ -450,24 +450,40 @@
         },
         "optional": true
       },
-      "bedroom": {
+      "rooms": {
         "type": "objectAttribute",
         "value": {
-          "type": "number"
-        },
-        "optional": true
-      },
-      "bathroom": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "number"
-        },
-        "optional": true
-      },
-      "nulti_purpose_area": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "number"
+          "type": "array",
+          "of": {
+            "type": "object",
+            "attributes": {
+              "room_title": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string"
+                },
+                "optional": true
+              },
+              "quantity": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "number"
+                },
+                "optional": true
+              }
+            },
+            "rest": {
+              "type": "object",
+              "attributes": {
+                "_key": {
+                  "type": "objectAttribute",
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         },
         "optional": true
       },
@@ -646,7 +662,30 @@
       "author": {
         "type": "objectAttribute",
         "value": {
-          "type": "string"
+          "type": "object",
+          "attributes": {
+            "_ref": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              }
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "reference"
+              }
+            },
+            "_weak": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "boolean"
+              },
+              "optional": true
+            }
+          },
+          "dereferencesTo": "author"
         },
         "optional": true
       },
@@ -975,6 +1014,112 @@
                 }
               }
             ]
+          }
+        },
+        "optional": true
+      }
+    }
+  },
+  {
+    "name": "author",
+    "type": "document",
+    "attributes": {
+      "_id": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_type": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string",
+          "value": "author"
+        }
+      },
+      "_createdAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_updatedAt": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "_rev": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        }
+      },
+      "name": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
+        },
+        "optional": true
+      },
+      "profile": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "asset": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "_ref": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "reference"
+                    }
+                  },
+                  "_weak": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "boolean"
+                    },
+                    "optional": true
+                  }
+                },
+                "dereferencesTo": "sanity.imageAsset"
+              },
+              "optional": true
+            },
+            "hotspot": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageHotspot"
+              },
+              "optional": true
+            },
+            "crop": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "inline",
+                "name": "sanity.imageCrop"
+              },
+              "optional": true
+            },
+            "_type": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string",
+                "value": "image"
+              }
+            }
           }
         },
         "optional": true

--- a/sanity/schemaTypes/author.js
+++ b/sanity/schemaTypes/author.js
@@ -1,0 +1,24 @@
+export default {
+  name: 'author',
+  type: 'document',
+  title: 'Author',
+  fields: [
+    {
+      name: 'name',
+      type: 'string',
+      title: 'Name',
+      validation: (rule) => rule.required(),
+    },
+    {
+      name: 'profile',
+      title: 'Profile image',
+      type: 'image',
+      options: {
+        hotspot: true,
+        accept: 'image/*',
+        storeOriginalFilename: true,
+      },
+      validation: (rule) => rule.required(),
+    },
+  ],
+}

--- a/sanity/schemaTypes/blog.js
+++ b/sanity/schemaTypes/blog.js
@@ -58,6 +58,11 @@ export default {
       name: 'main_image',
       title: 'Main Image',
       type: 'image',
+      options: {
+        hotspot: true,
+        accept: 'image/*',
+        storeOriginalFilename: true,
+      },
       validation: (Rule) => Rule.required(),
     },
     {
@@ -72,6 +77,8 @@ export default {
           type: 'image',
           options: {
             hotspot: true,
+            accept: 'image/*',
+            storeOriginalFilename: true,
           },
           fields: [
             {

--- a/sanity/schemaTypes/blog.js
+++ b/sanity/schemaTypes/blog.js
@@ -42,6 +42,8 @@ export default {
       name: 'author',
       title: 'Author',
       type: 'string',
+      type: 'reference',
+      to: [{ type: 'author' }],
       validation: (Rule) => Rule.required(),
     },
     {

--- a/sanity/schemaTypes/blog.js
+++ b/sanity/schemaTypes/blog.js
@@ -3,7 +3,9 @@ function toThaiSlug(inputString) {
     .replace(/\s+/g, '-')
     .replace(/%/g, 'เปอร์เซนต์')
     .replace(/[\u0300-\u036f]/g, '')
-    .replace(/--+/, '-')
+    .replace(/[\/\\]/g, '')
+    .replace(/[.,;:!?"'@#$%^&*()\[\]{}<>|~\/\\+=]/g, '')
+    .replace(/--+/g, '-')
     .replace(/^-+|-+$/g, '')
 
   return slug
@@ -31,6 +33,12 @@ export default {
       validation: (rule) => rule.required(),
     },
     {
+      name: 'short_description',
+      title: 'Short Description',
+      type: 'text',
+      validation: (rule) => rule.required().max(180),
+    },
+    {
       name: 'author',
       title: 'Author',
       type: 'string',
@@ -53,8 +61,8 @@ export default {
       validation: (Rule) => Rule.required(),
     },
     {
-      name: 'blog_description',
-      title: 'Blog Description',
+      name: 'content',
+      title: 'Content',
       type: 'array',
       of: [
         {

--- a/sanity/schemaTypes/catalogue.js
+++ b/sanity/schemaTypes/catalogue.js
@@ -48,22 +48,29 @@ export default {
         }),
     },
     {
-      name: 'bedroom',
-      title: 'Bedroom ',
-      type: 'number',
-      validation: (rule) => rule.required().positive().integer(),
-    },
-    {
-      name: 'bathroom',
-      title: 'Bathroom ',
-      type: 'number',
-      validation: (rule) => rule.required().positive().integer(),
-    },
-    {
-      name: 'nulti_purpose_area',
-      title: 'Multi-Purpose Area ',
-      type: 'number',
-      validation: (rule) => rule.required().positive().integer(),
+      name: 'rooms',
+      title: 'Rooms',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            {
+              name: 'room_title',
+              title: 'Room Title',
+              type: 'string',
+              validation: (rule) => rule.required(),
+            },
+            {
+              name: 'quantity',
+              title: 'Quantity',
+              type: 'number',
+              validation: (rule) => rule.required().positive().integer(),
+            },
+          ],
+        },
+      ],
+      validation: (rule) => rule.required(),
     },
     {
       name: 'price',

--- a/sanity/schemaTypes/catalogue.js
+++ b/sanity/schemaTypes/catalogue.js
@@ -14,6 +14,7 @@ export default {
       title: 'Main Image',
       type: 'image',
       options: {
+        hotspot: true,
         accept: 'image/*',
         storeOriginalFilename: true,
       },
@@ -84,7 +85,7 @@ export default {
               type: 'string',
               validation: (rule) => rule.required(),
             },
-           
+
             {
               name: 'image_sets',
               title: 'Image Sets',
@@ -92,6 +93,7 @@ export default {
               of: [{type: 'image'}],
               options: {
                 layout: 'grid',
+                hotspot: true,
                 accept: 'image/*',
                 storeOriginalFilename: true,
               },

--- a/sanity/schemaTypes/catalogue.js
+++ b/sanity/schemaTypes/catalogue.js
@@ -14,7 +14,7 @@ export default {
       title: 'Main Image',
       type: 'image',
       options: {
-        accept: '.jpg,.jpeg,.png',
+        accept: 'image/*',
         storeOriginalFilename: true,
       },
       validation: (rule) => rule.required(),
@@ -30,7 +30,7 @@ export default {
             {
               name: 'model',
               title: 'Model',
-              type: 'number',
+              type: 'string',
               validation: (rule) => rule.required(),
             },
             {
@@ -42,41 +42,40 @@ export default {
             {
               name: 'area',
               title: 'Area (sq.m.)',
-              type: 'string',
-              validation: (rule) =>
-                rule
-                  .required()
-                  .custom((value) => {
-                    const regex = /^\d+(\.\d+)?m\s*x\s*\d+(\.\d+)?m$/;
-                    if (!regex.test(value)) {
-                      return 'Please provide the area in the format "length (m) x width (m)", for example: 16.5m x 18.5m';
-                    }
-                    return true;
-                  }),
+              type: 'number',
+              validation: (rule) => rule.required().positive(),
             },
             {
               name: 'land_area_require',
-              title: 'Land Area Require ',
-              type: 'number',
-              validation: (rule) => rule.required().positive(),
+              title: 'Land Area Requirement',
+              type: 'string',
+              description: 'Please provide the area in the format "length(m) x width(m)" e.g., 16.5m x 18.5m',
+              validation: (rule) =>
+                rule.required().custom((value) => {
+                  const regex = /^\d+(\.\d+)?m\s*x\s*\d+(\.\d+)?m$/
+                  if (!regex.test(value)) {
+                    return 'Area does not match the required format'
+                  }
+                  return true
+                }),
             },
             {
               name: 'bedroom',
               title: 'Bedroom ',
               type: 'number',
-              validation: (rule) => rule.required().positive(),
+              validation: (rule) => rule.required().positive().integer(),
             },
             {
               name: 'bathroom',
               title: 'Bathroom ',
               type: 'number',
-              validation: (rule) => rule.required().positive(),
+              validation: (rule) => rule.required().positive().integer(),
             },
             {
               name: 'nulti_purpose_area',
               title: 'Multi-Purpose Area ',
               type: 'number',
-              validation: (rule) => rule.required().positive(),
+              validation: (rule) => rule.required().positive().integer(),
             },
             {
               name: 'price',

--- a/sanity/schemaTypes/catalogue.js
+++ b/sanity/schemaTypes/catalogue.js
@@ -1,0 +1,102 @@
+export default {
+  name: 'catalogue',
+  title: 'Catalogue',
+  type: 'document',
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'main_image',
+      title: 'Main Image',
+      type: 'image',
+      options: {
+        accept: '.jpg,.jpeg,.png',
+        storeOriginalFilename: true,
+      },
+      validation: (rule) => rule.required(),
+    },
+    {
+      name: 'model_sets',
+      title: 'Model sets',
+      type: 'array',
+      of: [
+        {
+          type: 'object',
+          fields: [
+            {
+              name: 'model',
+              title: 'Model',
+              type: 'number',
+              validation: (rule) => rule.required(),
+            },
+            {
+              name: 'recommend_land_direction',
+              title: 'Recommend Land Direction',
+              type: 'string',
+              validation: (rule) => rule.required(),
+            },
+            {
+              name: 'area',
+              title: 'Area (sq.m.)',
+              type: 'string',
+              validation: (rule) =>
+                rule
+                  .required()
+                  .custom((value) => {
+                    const regex = /^\d+(\.\d+)?m\s*x\s*\d+(\.\d+)?m$/;
+                    if (!regex.test(value)) {
+                      return 'Please provide the area in the format "length (m) x width (m)", for example: 16.5m x 18.5m';
+                    }
+                    return true;
+                  }),
+            },
+            {
+              name: 'land_area_require',
+              title: 'Land Area Require ',
+              type: 'number',
+              validation: (rule) => rule.required().positive(),
+            },
+            {
+              name: 'bedroom',
+              title: 'Bedroom ',
+              type: 'number',
+              validation: (rule) => rule.required().positive(),
+            },
+            {
+              name: 'bathroom',
+              title: 'Bathroom ',
+              type: 'number',
+              validation: (rule) => rule.required().positive(),
+            },
+            {
+              name: 'nulti_purpose_area',
+              title: 'Multi-Purpose Area ',
+              type: 'number',
+              validation: (rule) => rule.required().positive(),
+            },
+            {
+              name: 'price',
+              title: 'Price',
+              type: 'number',
+              validation: (rule) => rule.required().positive(),
+            },
+            {
+              name: 'image_sets',
+              title: 'Image Sets',
+              type: 'array',
+              of: [{type: 'image'}],
+              options: {
+                layout: 'grid',
+              },
+              validation: (rule) => rule.required(),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/sanity/schemaTypes/catalogue.js
+++ b/sanity/schemaTypes/catalogue.js
@@ -20,6 +20,57 @@ export default {
       validation: (rule) => rule.required(),
     },
     {
+      name: 'recommend_land_direction',
+      title: 'Recommend Land Direction',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    },
+    {
+      name: 'area',
+      title: 'Area (sq.m.)',
+      type: 'number',
+      validation: (rule) => rule.required().positive(),
+    },
+    {
+      name: 'land_area_require',
+      title: 'Land Area Requirement',
+      type: 'string',
+      description:
+        'Please provide the area in the format "length(m) x width(m)" e.g., 16.5m x 18.5m',
+      validation: (rule) =>
+        rule.required().custom((value) => {
+          const regex = /^\d+(\.\d+)?m\s*x\s*\d+(\.\d+)?m$/
+          if (!regex.test(value)) {
+            return 'Area does not match the required format'
+          }
+          return true
+        }),
+    },
+    {
+      name: 'bedroom',
+      title: 'Bedroom ',
+      type: 'number',
+      validation: (rule) => rule.required().positive().integer(),
+    },
+    {
+      name: 'bathroom',
+      title: 'Bathroom ',
+      type: 'number',
+      validation: (rule) => rule.required().positive().integer(),
+    },
+    {
+      name: 'nulti_purpose_area',
+      title: 'Multi-Purpose Area ',
+      type: 'number',
+      validation: (rule) => rule.required().positive().integer(),
+    },
+    {
+      name: 'price',
+      title: 'Price',
+      type: 'number',
+      validation: (rule) => rule.required().positive(),
+    },
+    {
       name: 'model_sets',
       title: 'Model sets',
       type: 'array',
@@ -28,61 +79,12 @@ export default {
           type: 'object',
           fields: [
             {
-              name: 'model',
-              title: 'Model',
+              name: 'title',
+              title: 'Title',
               type: 'string',
               validation: (rule) => rule.required(),
             },
-            {
-              name: 'recommend_land_direction',
-              title: 'Recommend Land Direction',
-              type: 'string',
-              validation: (rule) => rule.required(),
-            },
-            {
-              name: 'area',
-              title: 'Area (sq.m.)',
-              type: 'number',
-              validation: (rule) => rule.required().positive(),
-            },
-            {
-              name: 'land_area_require',
-              title: 'Land Area Requirement',
-              type: 'string',
-              description: 'Please provide the area in the format "length(m) x width(m)" e.g., 16.5m x 18.5m',
-              validation: (rule) =>
-                rule.required().custom((value) => {
-                  const regex = /^\d+(\.\d+)?m\s*x\s*\d+(\.\d+)?m$/
-                  if (!regex.test(value)) {
-                    return 'Area does not match the required format'
-                  }
-                  return true
-                }),
-            },
-            {
-              name: 'bedroom',
-              title: 'Bedroom ',
-              type: 'number',
-              validation: (rule) => rule.required().positive().integer(),
-            },
-            {
-              name: 'bathroom',
-              title: 'Bathroom ',
-              type: 'number',
-              validation: (rule) => rule.required().positive().integer(),
-            },
-            {
-              name: 'nulti_purpose_area',
-              title: 'Multi-Purpose Area ',
-              type: 'number',
-              validation: (rule) => rule.required().positive().integer(),
-            },
-            {
-              name: 'price',
-              title: 'Price',
-              type: 'number',
-              validation: (rule) => rule.required().positive(),
-            },
+           
             {
               name: 'image_sets',
               title: 'Image Sets',
@@ -90,6 +92,8 @@ export default {
               of: [{type: 'image'}],
               options: {
                 layout: 'grid',
+                accept: 'image/*',
+                storeOriginalFilename: true,
               },
               validation: (rule) => rule.required(),
             },

--- a/sanity/schemaTypes/deskStructure.js
+++ b/sanity/schemaTypes/deskStructure.js
@@ -1,0 +1,25 @@
+import {MdDescription, MdPerson} from 'react-icons/md'
+
+export const deskStructure = (S) =>
+  S.list()
+    .title('Content')
+    .items([
+      S.listItem()
+        .title('Page data')
+        .child(
+          S.list()
+            .title('Page data')
+            .items([
+              S.documentTypeListItem('blog').title('Blog').icon(MdDescription),
+              S.documentTypeListItem('portfolio').title('Portfolio').icon(MdDescription),
+              S.documentTypeListItem('catalogue').title('Catalogue').icon(MdDescription),
+            ]),
+        ),
+      S.listItem()
+        .title('User')
+        .child(
+          S.list()
+            .title('User')
+            .items([S.documentTypeListItem('author').title('Author').icon(MdPerson)]),
+        ),
+    ])

--- a/sanity/schemaTypes/index.js
+++ b/sanity/schemaTypes/index.js
@@ -1,5 +1,6 @@
-import portfolio from '../schemaTypes/portfolio.js'
-import blog from '../schemaTypes/blog.js'
+import portfolio from './portfolio.js'
+import blog from './blog.js'
 import catalogue from './catalogue.js'
+import author from './author.js'
 
-export const schemaTypes = [portfolio,blog,catalogue]
+export const schemaTypes = [portfolio, blog, catalogue, author]

--- a/sanity/schemaTypes/index.js
+++ b/sanity/schemaTypes/index.js
@@ -1,4 +1,5 @@
 import portfolio from '../schemaTypes/portfolio.js'
 import blog from '../schemaTypes/blog.js'
+import catalogue from './catalogue.js'
 
-export const schemaTypes = [portfolio,blog]
+export const schemaTypes = [portfolio,blog,catalogue]

--- a/sanity/schemaTypes/portfolio.js
+++ b/sanity/schemaTypes/portfolio.js
@@ -29,7 +29,8 @@ export default {
       title: 'Main Image',
       type: 'image',
       options: {
-        accept: '.jpg,.jpeg,.png',
+        hotspot: true,
+        accept: 'image/*',
         storeOriginalFilename: true,
       },
       validation: (rule) => rule.required(),
@@ -81,6 +82,9 @@ export default {
               of: [{type: 'image'}],
               options: {
                 layout: 'grid',
+                hotspot: true,
+                accept: 'image/*',
+                storeOriginalFilename: true,
               },
               validation: (rule) => rule.required(),
             },
@@ -109,6 +113,9 @@ export default {
               of: [{type: 'image'}],
               options: {
                 layout: 'grid',
+                hotspot: true,
+                accept: 'image/*',
+                storeOriginalFilename: true,
               },
               validation: (rule) => rule.required(),
             },

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -14,7 +14,6 @@ import {
 } from "@/components/ui/card"
 import Link from "next/link"
 import { BlogCard } from "@/types/Blog"
-import { SanityImageSource } from "@sanity/image-url/lib/types/types"
 
 async function getData() {
   const query = groq`
@@ -68,9 +67,11 @@ const components = {
 export default async function Blogs() {
   const data: BlogCard[] = await getData()
 
+  console.log(data)
+
   return (
     <div>
-      <h1>Portfolio</h1>
+      <h1>Blog</h1>
       <ul>
         {data.map((blog, index) => (
           <li key={index} className="w-fit">
@@ -90,11 +91,8 @@ export default async function Blogs() {
                       className="h-[200px] rounded-lg object-cover"
                     />
                   )}
-                  {blog.blog_description ? (
-                    <PortableText
-                      value={blog.blog_description}
-                      components={components}
-                    />
+                  {blog.short_description ? (
+                    <p>{blog.short_description}</p>
                   ) : (
                     <p>No description available</p>
                   )}

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -6,7 +6,7 @@ export const client = createClient({
   apiVersion: "2024-06-03",
   dataset: process.env.SANITY_STUDIO_DATASET,
   projectId: process.env.SANITY_STUDIO_PROJECT_ID,
-  useCdn: false,
+  useCdn: true,
   token: process.env.NEXT_PUBLIC_SANITY_TOKEN,
   perspective: "published",
 })

--- a/src/types/Blog.ts
+++ b/src/types/Blog.ts
@@ -6,5 +6,5 @@ export type BlogCard = {
   author: string
   release_date: Date
   main_image: Blog["main_image"]
-  blog_description: Blog["blog_description"]
+  short_description: Blog["short_description"]
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [x] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

1. Fix slug generation bug.
2. Fix website data not updating.
3. Add catalog schema.
4. Images can now be cropped and use hotspots.
5. Images can now be uploaded in every type of image file.

## Solution

1. The slug bug occurs because it doesn't remove '/' and '\\\' in the slug. When entering the site, it becomes "not found. Example -> "title:"`Tiger/\3080`" old slug:"`Tiger/\3080`"  new slug : "`Tiger3080`"
2. When updating data in Sanity, it doesn't appear on the website. This is because of the cache, so we need to set CDN to true.
3. Create a catalog schema based on the information provided on the old website.
4. For the new image feature, I set `hotspot: true` and `accept: 'image/*'` in the options.

## Side Effects

None

## Related Tickets & Documents

only image file : https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers
sanity image doc : https://www.sanity.io/docs/image-type

## Mobile & Desktop Screenshots/Recordings

Fixed slug
![image](https://github.com/Lukyord/Alvis/assets/116190378/b989eb9e-be77-47d7-96c0-9213d1062c71)

Sanity studio with catalogue
![image](https://github.com/Lukyord/Alvis/assets/116190378/b3b88d91-ee01-4c1e-99af-1172cc5a1df8)
![image](https://github.com/Lukyord/Alvis/assets/116190378/ea893e4f-cc1f-44dd-8dd7-db9ae4658bd8)

Crop & hospot
![image](https://github.com/Lukyord/Alvis/assets/116190378/e777fc4e-62a5-4a42-9feb-1c27f847dfe0)


## Note for KT
Don't worry about the deployment failure because I changed some variables that you mentioned earlier, so the variables are not the same. I have already extracted the schema for you. Feel free to edit the variables to match the schema.


- [x] add short description field
- [ ] author image & author profile page (เอาไงดี) link: https://www.alvis.co.th/profile/treesaran/profile
- [x] "block_description" change name to "content"
- [x] thai slug return null when fetched (attached image)